### PR TITLE
Allow use of connection string

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,11 +4,12 @@ The ``sprockets.clients.statsd`` package implements a simple statsd client that
 is used by the ``sprockets.mixins.statsd`` package. It can be used in your
 applications for sending metric values to statsd.
 
-The default statsd server that is used is ``localhost:8125``. The ``STATSD_HOST``
-and ``STATSD_PORT`` environment variables can be used to set the statsd server
-connection parameters. Note that the socket for communicating with statsd is
-created once upon module import and will not change until the application is
-restarted or the module is reloaded.
+The default statsd server that is used is ``localhost:8125``. The ``STATSD``
+environment variable can be used to set the statsd server connection parameters.
+This should take the form of a URL, such as ``udp://statsd.service:8675``.
+Note that the socket for communicating with statsd is created once upon module
+import and will not change until the application is restarted or the module is
+reloaded.
 
 |Version| |Downloads| |Status| |Coverage| |License|
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 coverage>=3.7,<4
 coveralls>=0.4,<1
 nose>=1.3,<2
+mock>=1.0.1,<2

--- a/tests.py
+++ b/tests.py
@@ -2,6 +2,7 @@
 Tests for the sprockets.clients.statsd package
 
 """
+import os
 import mock
 import socket
 try:
@@ -19,6 +20,18 @@ class SendTests(unittest.TestCase):
             statsd._send('foo.bar.baz', 2, 'c')
             sendto.assert_called_once_with(b'foo.bar.baz:2|c',
                                            ('localhost', 8125))
+
+    def test_statsd_url_format(self):
+        os.environ['STATSD'] = 'udp://statsd.service:8675'
+        statsd.set_address()
+
+        with mock.patch('socket.socket.sendto') as sendto:
+            statsd._send('foo.bar.baz', 2, 'c')
+            sendto.assert_called_once_with(b'foo.bar.baz:2|c',
+                                           ('statsd.service', 8675))
+
+        del os.environ['STATSD']
+        statsd.set_address()
 
     def test_socket_sendto_logs_exception(self):
         with mock.patch('socket.socket.sendto') as sendto:


### PR DESCRIPTION
While maintaining compatibility with the `STATSD_HOST` and `STATSD_PORT`
env vars, instead prefer the use of one `STATSD` url variable.
